### PR TITLE
Feat hermes

### DIFF
--- a/slack_sdk/version.py
+++ b/slack_sdk/version.py
@@ -1,2 +1,2 @@
 """Check the latest version at https://pypi.org/project/slack-sdk/"""
-__version__ = "3.13.0"
+__version__ = "3.13.0b1"

--- a/slack_sdk/web/async_client.py
+++ b/slack_sdk/web/async_client.py
@@ -1524,6 +1524,69 @@ class AsyncWebClient(AsyncBaseClient):
         )
         return await self.api_call("apps.event.authorizations.list", params=kwargs)
 
+    async def apps_notifications_subscriptions_create(
+        self,
+        *,
+        trigger_id: str,
+        channel_id: str,
+        name: str,
+        type: Optional[Dict[str, Any]] = None,
+        resource_link: Optional[str] = None,
+        **kwargs,
+    ) -> AsyncSlackResponse:
+        """Create a new notification subscription.
+        https://api.slack.com/methods/apps.notifications.subscriptions.create
+        """
+        kwargs.update(
+            {
+                "trigger_id": trigger_id,
+                "channel_id": channel_id,
+                "name": name,
+                "type": type,
+                "resource_link": resource_link,
+            }
+        )
+        return await self.api_call(
+            "apps.notifications.subscriptions.create",
+            params=kwargs,
+        )
+
+    async def apps_notifications_subscriptions_delete(
+        self,
+        *,
+        notification_subscription_id: str,
+        **kwargs,
+    ) -> AsyncSlackResponse:
+        """Remove a subscription in Slack
+        https://api.slack.com/methods/apps.notifications.subscriptions.delete
+        """
+        kwargs.update({"notification_subscription_id": notification_subscription_id})
+        return await self.api_call(
+            "apps.notifications.subscriptions.delete", params=kwargs
+        )
+
+    async def apps_notifications_subscriptions_update(
+        self,
+        *,
+        notification_subscription_id: str,
+        channel_id: str,
+        trigger_id: str,
+        **kwargs,
+    ) -> AsyncSlackResponse:
+        """Confirm a subscription has been updated.
+        https://api.slack.com/methods/apps.notifications.subscriptions.update
+        """
+        kwargs.update(
+            {
+                "notification_subscription_id": notification_subscription_id,
+                "channel_id": channel_id,
+                "trigger_id": trigger_id,
+            }
+        )
+        return await self.api_call(
+            "apps.notifications.subscriptions.update", params=kwargs
+        )
+
     async def apps_uninstall(
         self,
         *,
@@ -1978,6 +2041,7 @@ class AsyncWebClient(AsyncBaseClient):
         link_names: Optional[bool] = None,
         username: Optional[str] = None,
         parse: Optional[str] = None,  # none, full
+        metadata: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> AsyncSlackResponse:
         """Sends a message to a channel.
@@ -2002,6 +2066,7 @@ class AsyncWebClient(AsyncBaseClient):
                 "link_names": link_names,
                 "username": username,
                 "parse": parse,
+                "metadata": metadata,
             }
         )
         _parse_web_class_objects(kwargs)
@@ -2094,6 +2159,7 @@ class AsyncWebClient(AsyncBaseClient):
         link_names: Optional[bool] = None,
         parse: Optional[str] = None,  # none, full
         reply_broadcast: Optional[bool] = None,
+        metadata: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> AsyncSlackResponse:
         """Updates a message in a channel.
@@ -2110,6 +2176,7 @@ class AsyncWebClient(AsyncBaseClient):
                 "link_names": link_names,
                 "parse": parse,
                 "reply_broadcast": reply_broadcast,
+                "metadata": metadata,
             }
         )
         _parse_web_class_objects(kwargs)

--- a/slack_sdk/web/client.py
+++ b/slack_sdk/web/client.py
@@ -1477,6 +1477,65 @@ class WebClient(BaseClient):
         )
         return self.api_call("apps.event.authorizations.list", params=kwargs)
 
+    def apps_notifications_subscriptions_create(
+        self,
+        *,
+        trigger_id: str,
+        channel_id: str,
+        name: str,
+        type: Optional[Dict[str, Any]] = None,
+        resource_link: Optional[str] = None,
+        **kwargs,
+    ) -> SlackResponse:
+        """Create a new notification subscription.
+        https://api.slack.com/methods/apps.notifications.subscriptions.create
+        """
+        kwargs.update(
+            {
+                "trigger_id": trigger_id,
+                "channel_id": channel_id,
+                "name": name,
+                "type": type,
+                "resource_link": resource_link,
+            }
+        )
+        return self.api_call(
+            "apps.notifications.subscriptions.create",
+            params=kwargs,
+        )
+
+    def apps_notifications_subscriptions_delete(
+        self,
+        *,
+        notification_subscription_id: str,
+        **kwargs,
+    ) -> SlackResponse:
+        """Remove a subscription in Slack
+        https://api.slack.com/methods/apps.notifications.subscriptions.delete
+        """
+        kwargs.update({"notification_subscription_id": notification_subscription_id})
+        return self.api_call("apps.notifications.subscriptions.delete", params=kwargs)
+
+    def apps_notifications_subscriptions_update(
+        self,
+        *,
+        notification_subscription_id: str,
+        channel_id: str,
+        trigger_id: str,
+        **kwargs,
+    ) -> SlackResponse:
+        """Confirm a subscription has been updated.
+        https://api.slack.com/methods/apps.notifications.subscriptions.update
+        """
+        kwargs.update(
+            {
+                "notification_subscription_id": notification_subscription_id,
+                "channel_id": channel_id,
+                "trigger_id": trigger_id,
+            }
+        )
+        return self.api_call("apps.notifications.subscriptions.update", params=kwargs)
+
     def apps_uninstall(
         self,
         *,
@@ -1929,6 +1988,7 @@ class WebClient(BaseClient):
         link_names: Optional[bool] = None,
         username: Optional[str] = None,
         parse: Optional[str] = None,  # none, full
+        metadata: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> SlackResponse:
         """Sends a message to a channel.
@@ -1953,6 +2013,7 @@ class WebClient(BaseClient):
                 "link_names": link_names,
                 "username": username,
                 "parse": parse,
+                "metadata": metadata,
             }
         )
         _parse_web_class_objects(kwargs)
@@ -2045,6 +2106,7 @@ class WebClient(BaseClient):
         link_names: Optional[bool] = None,
         parse: Optional[str] = None,  # none, full
         reply_broadcast: Optional[bool] = None,
+        metadata: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> SlackResponse:
         """Updates a message in a channel.
@@ -2061,6 +2123,7 @@ class WebClient(BaseClient):
                 "link_names": link_names,
                 "parse": parse,
                 "reply_broadcast": reply_broadcast,
+                "metadata": metadata,
             }
         )
         _parse_web_class_objects(kwargs)

--- a/slack_sdk/web/legacy_client.py
+++ b/slack_sdk/web/legacy_client.py
@@ -1488,6 +1488,65 @@ class LegacyWebClient(LegacyBaseClient):
         )
         return self.api_call("apps.event.authorizations.list", params=kwargs)
 
+    def apps_notifications_subscriptions_create(
+        self,
+        *,
+        trigger_id: str,
+        channel_id: str,
+        name: str,
+        type: Optional[Dict[str, Any]] = None,
+        resource_link: Optional[str] = None,
+        **kwargs,
+    ) -> Union[Future, SlackResponse]:
+        """Create a new notification subscription.
+        https://api.slack.com/methods/apps.notifications.subscriptions.create
+        """
+        kwargs.update(
+            {
+                "trigger_id": trigger_id,
+                "channel_id": channel_id,
+                "name": name,
+                "type": type,
+                "resource_link": resource_link,
+            }
+        )
+        return self.api_call(
+            "apps.notifications.subscriptions.create",
+            params=kwargs,
+        )
+
+    def apps_notifications_subscriptions_delete(
+        self,
+        *,
+        notification_subscription_id: str,
+        **kwargs,
+    ) -> Union[Future, SlackResponse]:
+        """Remove a subscription in Slack
+        https://api.slack.com/methods/apps.notifications.subscriptions.delete
+        """
+        kwargs.update({"notification_subscription_id": notification_subscription_id})
+        return self.api_call("apps.notifications.subscriptions.delete", params=kwargs)
+
+    def apps_notifications_subscriptions_update(
+        self,
+        *,
+        notification_subscription_id: str,
+        channel_id: str,
+        trigger_id: str,
+        **kwargs,
+    ) -> Union[Future, SlackResponse]:
+        """Confirm a subscription has been updated.
+        https://api.slack.com/methods/apps.notifications.subscriptions.update
+        """
+        kwargs.update(
+            {
+                "notification_subscription_id": notification_subscription_id,
+                "channel_id": channel_id,
+                "trigger_id": trigger_id,
+            }
+        )
+        return self.api_call("apps.notifications.subscriptions.update", params=kwargs)
+
     def apps_uninstall(
         self,
         *,
@@ -1940,6 +1999,7 @@ class LegacyWebClient(LegacyBaseClient):
         link_names: Optional[bool] = None,
         username: Optional[str] = None,
         parse: Optional[str] = None,  # none, full
+        metadata: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Sends a message to a channel.
@@ -1964,6 +2024,7 @@ class LegacyWebClient(LegacyBaseClient):
                 "link_names": link_names,
                 "username": username,
                 "parse": parse,
+                "metadata": metadata,
             }
         )
         _parse_web_class_objects(kwargs)
@@ -2056,6 +2117,7 @@ class LegacyWebClient(LegacyBaseClient):
         link_names: Optional[bool] = None,
         parse: Optional[str] = None,  # none, full
         reply_broadcast: Optional[bool] = None,
+        metadata: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Updates a message in a channel.
@@ -2072,6 +2134,7 @@ class LegacyWebClient(LegacyBaseClient):
                 "link_names": link_names,
                 "parse": parse,
                 "reply_broadcast": reply_broadcast,
+                "metadata": metadata,
             }
         )
         _parse_web_class_objects(kwargs)

--- a/tests/slack_sdk_async/web/test_web_client_coverage.py
+++ b/tests/slack_sdk_async/web/test_web_client_coverage.py
@@ -55,6 +55,10 @@ class TestWebClientCoverage(unittest.TestCase):
                 "apps.manifest.update",
                 "apps.manifest.validate",
                 "tooling.tokens.rotate",
+                # TODO: Subscribe in Slack APIs
+                "apps.notifications.subscriptions.create",
+                "apps.notifications.subscriptions.delete",
+                "apps.notifications.subscriptions.update",
             ]:
                 continue
             self.api_methods_to_call.append(api_method)


### PR DESCRIPTION
## Summary

(Describe the goal of this PR. Mention any related issue numbers)

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [x] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [ ] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
